### PR TITLE
Handle builds that take longer than 3 minutes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-deploy-heroku",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "author": "Corey Donohoe <atmos@atmos.org>",
   "description": "Helpers to deploy to heroku with hubot-deploy",
   "main": "index.coffee",

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -33,7 +33,7 @@ class TokenVerifier
 
 class Reaper
   constructor: (@info, @status, @logger) ->
-    @maxTries = 18
+    @maxTries = 45
     @sleepFor = 10
 
   log: (string) ->


### PR DESCRIPTION
Some builds take longer than 3 minutes. Builds will eventually succeed but we've already given up and flagged them as failed in the GitHub API. This increases it to 7.5 minutes max.